### PR TITLE
The bug fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,11 +27,11 @@ OBJECTS = $(SOURCE:.f=.o)
 
 mcluster_sse: $(OBJECTS) $(LFLAGS)
 	$(CC) -c main.c -D SSE -lm
-	$(CC) $(CFLAGS) $(OBJECTS) main.o -o mcluster_sse -lm 
+	$(CC) $(OBJECTS) main.o -o mcluster_sse -lm $(CFLAGS) 
 
 mcluster_gpu: $(OBJECTS) $(LFLAGS) gpupot.gpu.o main.c
 	$(CC) -c main.c -D SSE -D GPU -lm -I$(CUDA_PATH)/include
-	$(CC) $(CFLAGS) $(OBJECTS) main.o gpupot.gpu.o -L$(CUDA_PATH)/lib64 -lcudart -lstdc++ -o mcluster_gpu -lm
+	$(CC) $(OBJECTS) main.o gpupot.gpu.o  -o mcluster_gpu -L$(CUDA_PATH)/lib64 -lcudart -lstdc++ -lm $(CFLAGS) 
 
 mcluster: 
 	$(CC) -o mcluster main.c -lm

--- a/main.c
+++ b/main.c
@@ -219,7 +219,7 @@ int main (int argv, char **argc) {
 			if (mn < MAX_MN) { 
 				mlim[mn] = atof(optarg);
 				if (mn == 0) mlow = atof(optarg);
-				if (mn == 1) mup = atof(optarg);
+				if (mn == MAX_MN-1) mup = atof(optarg);
 				mn++; 
 				break;
 			} else { printf("\nError: Number of mass params exceded maximum limit of %d\n", MAX_MN); return 1; }


### PR DESCRIPTION
Hi Andreas,

I find a bug in (-f2) multiple power-law IMF function generator. The maximum mass is not corrected set and cause wrong IMF. 
I fixed the bug. 
But I am not sure whether it will influence standard Kroupa 2001 IMF.
Maybe it is better you can double check it.

Bests.
Long Wang
